### PR TITLE
Improve error handling after connect

### DIFF
--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -202,6 +202,10 @@ RedisClustr.prototype.getSlots = function(cb) {
     }
 
     client.cluster('slots', function(err, slots) {
+      if (!err && slots.length === 0) {
+        err = new Error('no slots found, cluster is not in ok state yet')
+      }
+
       if (err) {
         // exclude this client from then next attempt
         exclude.push(client.address);

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -192,7 +192,6 @@ RedisClustr.prototype.getSlots = function(cb) {
   var exclude = [];
   var tryErrors = null;
   var tryClient = function() {
-    if (typeof readyTimeout !== 'undefined') clearTimeout(readyTimeout);
     if (self.quitting) return runCbs(new Error('cluster is quitting'));
 
     var client = self.getRandomConnection(exclude, true);

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -185,10 +185,6 @@ RedisClustr.prototype.getSlots = function(cb) {
     self._slotQ = false;
   };
 
-  self.once('fullReady', function() {
-    runCbs(null, self.slots)
-  })
-
   var exclude = [];
   var tryErrors = null;
   var tryClient = function() {
@@ -233,10 +229,13 @@ RedisClustr.prototype.getSlots = function(cb) {
         self.emit('ready');
       }
 
-      if (!self.fullReady) {
+      if (self.fullReady) {
+        runCbs(null, self.slots);
+      } else {
         self._waitUntilAllReady(seenClients, function() {
           self.fullReady = true;
           self.emit('fullReady');
+          runCbs(null, self.slots);
         })
       }
     });


### PR DESCRIPTION
This PR fixes two issues:

* If RedisClustr connects when the cluster is not yet in the 'ok' state, it would continue to return "couldn't get slot allocation" errors even after the cluster reached the 'ok' state.

* If RedisClustr fails to connect before the 'wait' timeout, it would continue to return "couldn't get slot allocation" errors even after the cluster became reachable.